### PR TITLE
Used new coerce_pattern dependency to simplify both unit tests and code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,54 @@
 version = 4
 
 [[package]]
+name = "coerce_pattern"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24aefb30a99538c723562bd8b129e2cdfd0e6f22416d2911dfd16895b1707188"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "srtim"
 version = "0.1.0"
+dependencies = [
+ "coerce_pattern",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+coerce_pattern = "0.1.0"


### PR DESCRIPTION
This pull request uses the `coerce_pattern` crate's `coerce_pattern!` and `assert_pattern!` macros to simplify unit tests involving complex patterns. It also uses `coerce_pattern!` in the production code in cases where we have guarantees that the compiler doesn't understand that the given pattern will hold.