### PR TITLE
fix: make Error enum implement std::error::Error trait

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -419,6 +419,8 @@ impl Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Since `Error` struct already implements `Debug` and `Display` traits, it can implement the `Error` trait without additional method implementations. This PR does that.