### PR TITLE
feat: allow for filtering for runs that take place during other runs when computing stats

### DIFF
--- a/src/segment_info.rs
+++ b/src/segment_info.rs
@@ -10,9 +10,7 @@ use std::thread;
 
 use crate::coerce_pattern;
 use crate::error::{Error, Result};
-use crate::segment_run::{
-    SegmentRun, SegmentRunEvent, SegmentStats, SupplementedSegmentRun,
-};
+use crate::segment_run::{SegmentRun, SegmentRunEvent, SupplementedSegmentRun};
 use crate::utils::zip_same;
 
 /// Ensures that display_name doesn't have a tab,
@@ -418,13 +416,13 @@ impl<'a> RunPart<'a> {
         }
     }
 
-    /// Gets the stats of the full run part
-    pub fn get_stats(&self) -> Result<Option<SegmentStats>> {
+    /// Gets all runs of the given run part
+    pub fn get_runs(&self) -> Result<Arc<[SegmentRun]>> {
         match SegmentRun::load_all(self.file_name()) {
-            Ok(runs) => Ok(SegmentStats::from_runs(&runs)),
+            Ok(runs) => Ok(runs),
             Err(Error::CouldNotReadSegmentRunFile { path, error }) => {
                 if error.kind() == ErrorKind::NotFound {
-                    Ok(None)
+                    Ok(Arc::new([]))
                 } else {
                     Err(Error::CouldNotReadSegmentRunFile { path, error })
                 }


### PR DESCRIPTION
This PR:
* represents a start and end time through a new `Interval` struct
* allows for filtering when creating stats from runs. Instead of all runs, you can consider all runs of segment A that took place during segment B